### PR TITLE
style(detail): 詳細画面のヘッダー画像削除とレイアウト調整、コメント形式の統一

### DIFF
--- a/frontend/components/Spot_detail/Detail.tsx
+++ b/frontend/components/Spot_detail/Detail.tsx
@@ -32,9 +32,6 @@ const Map = dynamic(() => import('@/components/Spot_detail/Map'), {
 export default function Detail({ proSpotDetail, interests, spotType, spotId, children }: Props) {
   const router = useRouter();
 
-  // ヘッダー画像を削除するため、imageSrcは使用しなくなりますがコメントアウトして残します
-  // const imageSrc = proSpotDetail.img || 'https://placehold.jp/800x400.png?text=No+Image';
-
   // 「ここに行く」ボタン用のURL (Googleマップのサイトへ遷移)
   const googleMapsLink = `https://www.google.com/maps?q=${proSpotDetail.lat},${proSpotDetail.lon}`;
 


### PR DESCRIPTION
ヘッダー画像の非表示化: 上部の画像エリアを削除（コードはコメントアウトとして保持）し、画面をシンプルにしました。

ナビゲーションの配置変更: 「戻るボタン」と「スポット名（タイトル）」を、左側のスクロールパネル内に移動しました。

境界線の削除:
「スポット概要」タイトルの下線 (border-b) を削除。
周辺情報エリアの上線 (border-t) を削除。
コード整理: 強調用のコメントマーカー（▼▼▼等）を取り除き、通常のコメント形式に統一しました。

確認方法 (How to check)
以下のポイントが正しく反映されているか、ブラウザで確認をお願いします。

ヘッダー画像の消失確認

[ ] 画面最上部に大きな画像が表示されていないこと。

タイトルと戻るボタンの位置

[ ] 画面左側のパネルの一番上に、「戻るボタン（<）」と「スポット名」が表示されていること。

[ ] 左パネルをスクロールした際、タイトルとボタンも一緒にスクロールして見えなくなる（固定されていない）こと。

境界線の確認

[ ] 「● スポット概要」という文字の下に、グレーの線が入っていないこと。

[ ] 「周辺の観光地/グルメ」リストの直上に、区切りの線が入っていないこと。

動作確認

[ ] 「戻るボタン」を押して、前の画面（クイズ結果画面など）に戻れること。

[ ] 右側の地図はスクロールせず、固定表示されていること。